### PR TITLE
Allow reporters to handle successful files

### DIFF
--- a/lib/report.js
+++ b/lib/report.js
@@ -46,11 +46,11 @@ module.exports = function simpleReport(options) {
     var failed = false;
     var reporter = loadReporter(options && options.reporter);
     var s = through.obj(function gulpSimpleReporter(file, enc, cb) {
-        if (file.jshint && !file.jshint.success && !file.jshint.ignored) {
+        if (file.jshint && !file.jshint.ignored) {
             var fileOptions = xtend(options, file.jshint.opt);
             reporter(file.jshint.results, file.jshint.data, fileOptions);
 
-            if (options && options.emitError) {
+            if (!file.jshint.success && options && options.emitError) {
                 var fileErr = new gutil.PluginError(pluginName, "Lint failed", {});
                 fileErr.code = "ELINT";
                 this.emit("error", fileErr);


### PR DESCRIPTION
It should be up to the linter reporter to decide whether or not to display files that have successfully passed the linter. It's useful, for instance, to show on Jenkins all the files that have been tested.
